### PR TITLE
照準用マーカー表示の常時オンオフ機能の追加

### DIFF
--- a/Assets/Scenes/Home.unity
+++ b/Assets/Scenes/Home.unity
@@ -134,12 +134,12 @@ GameObject:
   - component: {fileID: 772003784}
   - component: {fileID: 772003783}
   m_Layer: 0
-  m_Name: Home
+  m_Name: "Home(Title \u3068\u540C\u3058\u6A5F\u80FD)"
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &772003783
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -170,7 +170,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &787479420
 PrefabInstance:
@@ -187,7 +187,7 @@ PrefabInstance:
     - target: {fileID: 170027660724109191, guid: fe098da34a90e6c428ae1c178e830675,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 170027660724109191, guid: fe098da34a90e6c428ae1c178e830675,
         type: 3}
@@ -239,6 +239,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 170027660724109208, guid: fe098da34a90e6c428ae1c178e830675,
+        type: 3}
+      propertyPath: stagePathDataSO
+      value: 
+      objectReference: {fileID: 11400000, guid: eab1913d05ce1ee45bd95f50f8dc9324,
+        type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fe098da34a90e6c428ae1c178e830675, type: 3}
 --- !u!1001 &982354043
@@ -251,7 +257,7 @@ PrefabInstance:
     - target: {fileID: 8504809058466120665, guid: f3079edf7e3b38c4994c8e0d141b46d7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8504809058466120665, guid: f3079edf7e3b38c4994c8e0d141b46d7,
         type: 3}
@@ -306,7 +312,7 @@ PrefabInstance:
     - target: {fileID: 8504809058466120666, guid: f3079edf7e3b38c4994c8e0d141b46d7,
         type: 3}
       propertyPath: clearStageNoList.Array.size
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8504809058466120666, guid: f3079edf7e3b38c4994c8e0d141b46d7,
         type: 3}
@@ -335,7 +341,7 @@ PrefabInstance:
     - target: {fileID: 5715994627197856263, guid: 53fae06026bed8c48bd3547f48409407,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5715994627197856263, guid: 53fae06026bed8c48bd3547f48409407,
         type: 3}
@@ -416,7 +422,8 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 7204629140827451195}
   m_Father: {fileID: 1449320582}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -635,13 +642,62 @@ RectTransform:
   m_Children:
   - {fileID: 1377423530}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1512486200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512486202}
+  - component: {fileID: 1512486201}
+  m_Layer: 0
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1512486201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512486200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2eeec74db5b5fe2429f651202cea6ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  stageButtonPrefab: {fileID: -4847079802813730159, guid: 0a914eea86267fd4398ac8b5c6ab1f25,
+    type: 3}
+  stageButtonTran: {fileID: 1377423530}
+  stageButtonList: []
+  debugStageNos: 
+  isLoadData: 0
+--- !u!4 &1512486202
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512486200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1793997153
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -942,7 +998,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2145563055
 GameObject:
@@ -985,5 +1041,220 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7204629140827451140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7204629140827451195}
+  - component: {fileID: 7204629140827451192}
+  - component: {fileID: 7204629140827451193}
+  - component: {fileID: 7204629140827451194}
+  - component: {fileID: 7973150053875247465}
+  m_Layer: 5
+  m_Name: StageButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &7204629140827451192
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629140827451140}
+  m_CullTransparentMesh: 1
+--- !u!114 &7204629140827451193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629140827451140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7204629140827451194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629140827451140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7204629140827451193}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!224 &7204629140827451195
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629140827451140}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7204629141682300735}
+  m_Father: {fileID: 1377423530}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7204629141682300728
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7204629141682300735}
+  - component: {fileID: 7204629141682300733}
+  - component: {fileID: 7204629141682300734}
+  m_Layer: 5
+  m_Name: txtstageName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &7204629141682300733
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629141682300728}
+  m_CullTransparentMesh: 1
+--- !u!114 &7204629141682300734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629141682300728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!224 &7204629141682300735
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629141682300728}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7204629140827451195}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7973150053875247465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7204629140827451140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 356b0d7454c7d414b9d52926799db7b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  btnChoose: {fileID: 7204629140827451194}
+  txtStageName: {fileID: 7204629141682300734}

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -193,7 +193,7 @@ PrefabInstance:
     - target: {fileID: 8916549146485933457, guid: a59b0609ea2fa5f44823a30f5c7ce800,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8916549146485933457, guid: a59b0609ea2fa5f44823a30f5c7ce800,
         type: 3}
@@ -1093,9 +1093,9 @@ Transform:
   m_Children:
   - {fileID: 8264416041326420978}
   - {fileID: 8264416041290695432}
-  - {fileID: 8264416041433775745}
   - {fileID: 1848547289}
   - {fileID: 32074553}
+  - {fileID: 8264416041433775745}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3577,7 +3577,7 @@ MonoBehaviour:
   autoScroller: {fileID: 0}
   txtStopMotionCount: {fileID: 0}
   txtARIntroduction: {fileID: 0}
-  targetIcon: {fileID: 0}
+  targetIcon: {fileID: 1819377530}
   txtBulletCount: {fileID: 0}
   txtScore: {fileID: 0}
 --- !u!1001 &1359902572
@@ -4335,6 +4335,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1724487860}
   m_CullTransparentMesh: 1
+--- !u!1 &1819377530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1819377533}
+  - component: {fileID: 1819377532}
+  - component: {fileID: 1819377531}
+  m_Layer: 5
+  m_Name: TargetIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1819377531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819377530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c4aafc13f7939234e9d79b53b2fcba70, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1819377532
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819377530}
+  m_CullTransparentMesh: 1
+--- !u!224 &1819377533
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819377530}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7590395237101197920}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1848547288
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4345,7 +4420,7 @@ PrefabInstance:
     - target: {fileID: 6239359517610320279, guid: 67f716418f7ba2146a845739c7782755,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6239359517610320279, guid: 67f716418f7ba2146a845739c7782755,
         type: 3}
@@ -5370,6 +5445,7 @@ RectTransform:
   - {fileID: 7590395238265765317}
   - {fileID: 7590395237779910519}
   - {fileID: 7590395238087955877}
+  - {fileID: 1819377533}
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -8574,7 +8650,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 454872042}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8264416041433775774
 GameObject:
@@ -8585,9 +8661,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8264416041433775745}
-  - component: {fileID: 8264416041433775775}
-  - component: {fileID: 8264416041433775777}
-  - component: {fileID: 8264416041433775776}
   m_Layer: 0
   m_Name: Target
   m_TagString: Player
@@ -8595,70 +8668,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!136 &8264416041433775775
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8264416041433775774}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  m_Radius: 0.5
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &8264416041433775776
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8264416041433775774}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 18858803709778759, guid: 857241dcf6bb2ea45a0b3f46d78f44b5, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &8264416041433775777
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8264416041433775774}
-  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &8504809057893998795
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameData.cs
+++ b/Assets/Scripts/GameData.cs
@@ -35,6 +35,7 @@ public class GameData : MonoBehaviour
     public const string CLEAR_STAGES_KEY = "ClearStageNosList";
     public const string SAVE_KEY = "SaveData";        // SaveData ƒNƒ‰ƒX—p‚Ì Key
 
+    public bool isTargetMarker;
 
 
     void Awake() {

--- a/Assets/Scripts/TransitionManager.cs
+++ b/Assets/Scripts/TransitionManager.cs
@@ -46,7 +46,11 @@ public class TransitionManager : MonoBehaviour {
         Debug.Log("FadeOut_Start");
     }
 
-
+    /// <summary>
+    /// フェードインの後に次のシーンの読み込み
+    /// </summary>
+    /// <param name="duration"></param>
+    /// <param name="nextSceneName"></param>
     public void FadeNextScene(float duration, SceneName nextSceneName) {
         fade.FadeIn(duration, () => {
             // フェードイン後に次のシーンの読み込み

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -89,6 +89,8 @@ public class UIManager : MonoBehaviour
 
         //this.maxBulletCount = maxBulletCount;
         //UpdateDisplayBulletCount(this.maxBulletCount);
+
+        SwitchActivateTargetIcon(GameData.instance.isTargetMarker);
     }
 
     /// <summary>
@@ -197,6 +199,10 @@ public class UIManager : MonoBehaviour
         txtDebugMessage.text = message;
     }
 
+    /// <summary>
+    /// ターゲットマーカーのオンオフ切り替え
+    /// </summary>
+    /// <param name="isSwitch"></param>
     public void SwitchActivateTargetIcon(bool isSwitch) {
         targetIcon.SetActive(isSwitch);
     }
@@ -312,15 +318,9 @@ public class UIManager : MonoBehaviour
 
     void Update() {
 
-        //var screenPoint = Camera.main.WorldToScreenPoint(targetIcon.transform.position); // ワールド座標からスクリーン座標へ
-        //Ray ray = Camera.main.ScreenPointToRay(screenPoint);
-
-        // カメラの位置から正面に向かって Ray を投射
-
-        // クリックした位置用
-        //Vector3 pos = Camera.main.WorldToScreenPoint(Input.mousePosition);
-
-        // マウスの位置にターゲットマーカーを移動
-        targetIcon.transform.position = Input.mousePosition;
+        if (targetIcon != null && targetIcon.activeSelf) {
+            // マウスの位置にターゲットマーカーを移動
+            targetIcon.transform.position = Input.mousePosition;
+        }
     }
 }

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -45,12 +45,11 @@ public class UIManager : MonoBehaviour
     [SerializeField]
     private GameObject canvasObj;
 
-
-    //mi
-
     [SerializeField]
     private Button btnWeaponChange;
 
+
+    //mi
 
     [SerializeField]
     private Text txtDebugMessage;
@@ -77,6 +76,7 @@ public class UIManager : MonoBehaviour
 
     [SerializeField]
     private Text txtScore;
+
 
 
     /// <summary>
@@ -178,17 +178,16 @@ public class UIManager : MonoBehaviour
         canvasObj.SetActive(isSwitch);
     }
 
-
-    // mi
-
     /// <summary>
     /// 武器交換ボタンの取得
     /// </summary>
     /// <returns></returns>
-    public Button GetWeaponChnageButton() {
+    public Button GetWeaponChangeButton() {
         return btnWeaponChange;
     }
 
+
+    // mi
 
     /// <summary>
     /// デバッグ内容を画面表示
@@ -308,5 +307,20 @@ public class UIManager : MonoBehaviour
     /// <returns></returns>
     public (bool, int) GetSubmitBranchNo() {
         return (isSubmitBranch, submitBranchNo);
+    }
+
+
+    void Update() {
+
+        //var screenPoint = Camera.main.WorldToScreenPoint(targetIcon.transform.position); // ワールド座標からスクリーン座標へ
+        //Ray ray = Camera.main.ScreenPointToRay(screenPoint);
+
+        // カメラの位置から正面に向かって Ray を投射
+
+        // クリックした位置用
+        //Vector3 pos = Camera.main.WorldToScreenPoint(Input.mousePosition);
+
+        // マウスの位置にターゲットマーカーを移動
+        targetIcon.transform.position = Input.mousePosition;
     }
 }


### PR DESCRIPTION
・ターゲットマーカー用の画像をインポート。UI にターゲットマーカー配置。
・UIManager..cs を修正し、マウスの位置にマーカーを移動させる機能を追加。
　マウスの位置に合わせて照準マーカーを常時表示する機能の追加。

・GameData.cs を修正し、マーカー表示の切り替え機能を追加。
・不要な処理を削除。ゲーム起動時のマーカー表示のオンオフ問題なし。デバッグ完了。