### PR TITLE
ロックオン機能の追加

### DIFF
--- a/Assets/Datas/StagePathDataSO 1.asset
+++ b/Assets/Datas/StagePathDataSO 1.asset
@@ -18,6 +18,9 @@ MonoBehaviour:
       railPathData: {fileID: 5006531821375082778, guid: 7370f2b440d9dbd4b80943df009d08c2,
         type: 3}
   - branchDatasList:
-    - branchDirectionType: 0
+    - branchDirectionType: 1
       railPathData: {fileID: 6572080289317892610, guid: 75d3b74badc2b9342b049af135f549a0,
+        type: 3}
+    - branchDirectionType: 2
+      railPathData: {fileID: 6572080289317892610, guid: 8e1e7ada8234e684f860ca1572ee204c,
         type: 3}

--- a/Assets/Fade/Materials/UI-Fade-Alpha.mat
+++ b/Assets/Fade/Materials/UI-Fade-Alpha.mat
@@ -24,7 +24,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MaskTex:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: e2bb0d9f9c35c3b41a89dd9729f6453c, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Ints: []

--- a/Assets/Prefabs/RailPathData.prefab
+++ b/Assets/Prefabs/RailPathData.prefab
@@ -194,16 +194,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pathDataDetails:
-  - railMoveDuration: 0
+  - railMoveDuration: 3
     pathTran: {fileID: 570193093635140365}
     isMissionTrigger: 0
     missionEventDetail: {fileID: 0}
-  - railMoveDuration: 0
+    isMoviePlay: 0
+  - railMoveDuration: 3
     pathTran: {fileID: 1809611501726687593}
     isMissionTrigger: 0
     missionEventDetail: {fileID: 0}
-  - railMoveDuration: 0
+    isMoviePlay: 0
+  - railMoveDuration: 3
     pathTran: {fileID: 4498685088563767508}
     isMissionTrigger: 0
     missionEventDetail: {fileID: 0}
+    isMoviePlay: 0
   smoothPath: {fileID: 2691927921452758599}

--- a/Assets/Prefabs/StageButton.prefab
+++ b/Assets/Prefabs/StageButton.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 3595591224220286149}
   - component: {fileID: 3595591224220286150}
   m_Layer: 5
-  m_Name: Text
+  m_Name: txtstageName
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -59,7 +59,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -78,7 +78,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Stage 1
+  m_Text: 
 --- !u!1 &3595591225882539260
 GameObject:
   m_ObjectHideFlags: 0
@@ -116,8 +116,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -131.844, y: 61.132}
-  m_SizeDelta: {x: 423.689, y: 388.505}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3595591225882539200
 CanvasRenderer:

--- a/Assets/Prefabs/TargetMarker —Pngtree—aiming circle shooting aiming picture_5466287.prefab
+++ b/Assets/Prefabs/TargetMarker —Pngtree—aiming circle shooting aiming picture_5466287.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6210581172330119267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7307608668779335958}
+  - component: {fileID: 4114067992890253330}
+  - component: {fileID: 3936477952231821727}
+  m_Layer: 0
+  m_Name: "TargetMarker \u2014Pngtree\u2014aiming circle shooting aiming picture_5466287"
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7307608668779335958
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6210581172330119267}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4114067992890253330
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6210581172330119267}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: c4aafc13f7939234e9d79b53b2fcba70, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 20}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &3936477952231821727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6210581172330119267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74b61e854efd6144da8d743394e201a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/TargetMarker —Pngtree—aiming circle shooting aiming picture_5466287.prefab.meta
+++ b/Assets/Prefabs/TargetMarker —Pngtree—aiming circle shooting aiming picture_5466287.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bec2385a45a92354482412dde41561f3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/btnSubmitBranch.prefab
+++ b/Assets/Prefabs/btnSubmitBranch.prefab
@@ -67,7 +67,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: 21300000, guid: f588d850485d0ae479d73cf3bd0b7b00, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -3572,12 +3572,12 @@ MonoBehaviour:
   isSubmitBranch: 0
   canvasObj: {fileID: 7590395237101197921}
   btnWeaponChange: {fileID: 2110976190}
+  targetIcon: {fileID: 1819377530}
   txtDebugMessage: {fileID: 0}
   btnStopMotion: {fileID: 0}
   autoScroller: {fileID: 0}
   txtStopMotionCount: {fileID: 0}
   txtARIntroduction: {fileID: 0}
-  targetIcon: {fileID: 1819377530}
   txtBulletCount: {fileID: 0}
   txtScore: {fileID: 0}
 --- !u!1001 &1359902572
@@ -4367,7 +4367,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -4403,7 +4403,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7590395237101197920}
-  m_RootOrder: 7
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5442,10 +5442,10 @@ RectTransform:
   - {fileID: 829164631}
   - {fileID: 7590395237285939684}
   - {fileID: 1680915432}
+  - {fileID: 1819377533}
   - {fileID: 7590395238265765317}
   - {fileID: 7590395237779910519}
   - {fileID: 7590395238087955877}
-  - {fileID: 1819377533}
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5615,7 +5615,7 @@ RectTransform:
   m_Children:
   - {fileID: 7590395238636004206}
   m_Father: {fileID: 7590395237101197920}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -5897,7 +5897,7 @@ RectTransform:
   m_Children:
   - {fileID: 7590395236664543328}
   m_Father: {fileID: 7590395237101197920}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6201,7 +6201,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7590395237101197920}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -8638,6 +8638,10 @@ MonoBehaviour:
   layerMasksStr: []
   playerController: {fileID: 454872043}
   arManager: {fileID: 0}
+  targetList: []
+  markerList: []
+  targetMarkerPrefab: {fileID: 3936477952231821727, guid: bec2385a45a92354482412dde41561f3,
+    type: 3}
 --- !u!4 &8264416041433775745
 Transform:
   m_ObjectHideFlags: 0
@@ -8729,6 +8733,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8504809058466120666, guid: f3079edf7e3b38c4994c8e0d141b46d7,
+        type: 3}
+      propertyPath: isTargetMarker
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8504809058466120667, guid: f3079edf7e3b38c4994c8e0d141b46d7,
         type: 3}

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -48,6 +48,9 @@ public class UIManager : MonoBehaviour
     [SerializeField]
     private Button btnWeaponChange;
 
+    [SerializeField]
+    private GameObject targetIcon;
+
 
     //mi
 
@@ -65,9 +68,6 @@ public class UIManager : MonoBehaviour
 
     [SerializeField]
     private Text txtARIntroduction;
-
-    [SerializeField]
-    private GameObject targetIcon;
 
     [SerializeField]
     private Text txtBulletCount;
@@ -207,6 +207,15 @@ public class UIManager : MonoBehaviour
         targetIcon.SetActive(isSwitch);
     }
 
+    void Update() {
+
+        if (targetIcon != null && targetIcon.activeSelf) {
+            // マウスの位置にターゲットマーカーを移動
+            targetIcon.transform.position = Input.mousePosition;
+        }
+    }
+
+
     public void SwitchActivatePlayerInfoSet(bool isSwitch) {
         playerInfoSet.SetActive(isSwitch);
     }
@@ -313,14 +322,5 @@ public class UIManager : MonoBehaviour
     /// <returns></returns>
     public (bool, int) GetSubmitBranchNo() {
         return (isSubmitBranch, submitBranchNo);
-    }
-
-
-    void Update() {
-
-        if (targetIcon != null && targetIcon.activeSelf) {
-            // マウスの位置にターゲットマーカーを移動
-            targetIcon.transform.position = Input.mousePosition;
-        }
     }
 }

--- a/Assets/TargetMarker.cs
+++ b/Assets/TargetMarker.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TargetMarker : MonoBehaviour
+{
+    private Transform targetTran;
+    private Vector3 offsetTargetMarker = new Vector3(0, 1.5f, 0.2f);
+    private float markerScale = 0.05f;
+
+    /// <summary>
+    /// マーカー設定
+    /// </summary>
+    /// <param name="target"></param>
+    public void SetUpTargetMarker(Transform target) {
+        targetTran = target;
+
+        transform.localPosition = offsetTargetMarker;
+        transform.localScale = Vector3.one * markerScale;
+    }
+
+    void Update()
+    {
+        if (!targetTran) {
+            return;
+        }
+
+        // マーカーを常にプレイヤー(カメラ)の方向に向ける
+        transform.LookAt(targetTran);
+    }
+}

--- a/Assets/TargetMarker.cs.meta
+++ b/Assets/TargetMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74b61e854efd6144da8d743394e201a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・ロックオン時に表示するマーカー用のアイコン・ゲームオブジェクト作成し、プレファブ化。
・TargetMarker.cs 作成。マーカーが常にカメラの方向を向くようにする。

・RayController.cs を修正し、攻撃ボタンを長押し中は対象をロックオンする機能を追加。合わせてマーカーを付与し、エフェクトの位置を保持。

・RayController.cs を修正し、攻撃ボタンを離した際に、弾の消費と、ロックオンした対象に対して順番に攻撃を行う機能を追加。
　ロックオン照準アイコンの削除とヒット位置へのエフェクトも追加。

・複数の対象をロックオンしての攻撃機能、弾数が足りない場合の制御機能、照準器の付与と削除、エフェクトの生成位置、いずれも問題なし。
・デバッグ完了。