### PR TITLE
イベントのバリエーションとゲーム内時間機能の追加

### DIFF
--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -4772,6 +4772,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2059168731}
   m_CullTransparentMesh: 1
+--- !u!1 &2095800633
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2095800634}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2095800634
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095800633}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2110976188
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -1032,6 +1032,7 @@ GameObject:
   - component: {fileID: 454872043}
   - component: {fileID: 454872045}
   - component: {fileID: 454872046}
+  - component: {fileID: 454872047}
   m_Layer: 0
   m_Name: Main Camera_Player
   m_TagString: MainCamera
@@ -1135,6 +1136,7 @@ MonoBehaviour:
   currentWeaponNo: 0
   bulletCountDatasList: []
   playerObj: {fileID: 8264416041433775774}
+  hideAction: {fileID: 0}
 --- !u!54 &454872044
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1199,6 +1201,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameManager: {fileID: 1550902661}
   cameraTran: {fileID: 454872042}
+--- !u!114 &454872047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454872039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ad283b0d643e824993f0cf9cb39c235, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameTime: 60
+  gameManager: {fileID: 0}
 --- !u!1 &560543691
 GameObject:
   m_ObjectHideFlags: 0
@@ -4772,37 +4788,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2059168731}
   m_CullTransparentMesh: 1
---- !u!1 &2095800633
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2095800634}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2095800634
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2095800633}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 19
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2110976188
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyBase.cs
+++ b/Assets/Scripts/EnemyBase.cs
@@ -184,12 +184,18 @@ public class EnemyBase : EventBase
     protected IEnumerator Attack(PlayerController player = null) {
         isAttack = true;
 
-        player.CalcHp(-attackPower);
+        // プレイヤーが隠れていない場合
+        if (!player.HideAction.IsHide) {
 
-        if (anim) {
-            anim.SetTrigger("Attack");
+            // プレイヤーにダメージを与える
+            player.CalcHp(-attackPower);
+
+            if (anim) {
+                anim.SetTrigger("Attack");
+            }
         }
 
+        // プレイヤーの状態にかかわらず攻撃後には待機
         yield return new WaitForSeconds(attackInterval);
 
         isAttack = false;
@@ -220,6 +226,8 @@ public class EnemyBase : EventBase
     /// <param name="damage"></param>
     /// <param name="hitParts"></param>
     protected virtual void CalcDamage(int damage, BodyRegionType hitParts) {
+
+        // エネミーが倒されている場合
         if (isDead) {
             return;
         }

--- a/Assets/Scripts/EnemyBase.cs
+++ b/Assets/Scripts/EnemyBase.cs
@@ -260,6 +260,11 @@ public class EnemyBase : EventBase
 
             // スコア加算
 
+            // このイベントに TimeEffect がアタッチされており、かつ、Player に GameTimeManager がアタッチされている場合
+            if (TryGetComponent(out TimeEffect timeEffect) && player.TryGetComponent(out GameTimeManager gameTimeManager)) {
+                // 時間の計算(黄色いエネミーは加算、一般人などの破壊してはダメなものは減算)
+                gameTimeManager.CalcGameTime(timeEffect.timeValue);
+            }
 
             Destroy(gameObject, 1.5f);
         } else {

--- a/Assets/Scripts/EnemyController_Elete.cs
+++ b/Assets/Scripts/EnemyController_Elete.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyController_Elete : EnemyBase
+{
+    public float waitTime;
+
+    public override void SetUpEvent(PlayerController playerController, GameManager gameManager) {
+        base.SetUpEvent(playerController, gameManager);
+
+        StartCoroutine(AttackRegularIntervals());
+    }
+
+    /// <summary>
+    /// ˆê’èŠÔŠu‚²‚Æ‚ÉŠm’èUŒ‚
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator AttackRegularIntervals() {
+
+        float timer = 0;
+
+        while (true) {
+            timer += Time.deltaTime;
+            if (timer > waitTime) {
+                timer = 0;
+                // UŒ‚—p‚Ìƒƒ\ƒbƒh‚ğ‘ã“ü‚µ‚Ä“o˜^
+                attackCoroutine = Attack(player);
+                StartCoroutine(attackCoroutine);
+            }
+            yield return null;
+        }
+    }
+}

--- a/Assets/Scripts/EnemyController_Elete.cs.meta
+++ b/Assets/Scripts/EnemyController_Elete.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f74e3d6468847f4786cd7f8ce6f5143
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EventGenerator.cs
+++ b/Assets/Scripts/EventGenerator.cs
@@ -96,7 +96,7 @@ public class EventGenerator : MonoBehaviour
 
         for (int i = 0; i < eventDatas.Length; i++) {
 
-            GenerateEvent(eventDatas[i], eventTrans[i]);
+            GenerateEnemy(eventDatas[i], eventTrans[i]);
         }
      }
 
@@ -106,7 +106,7 @@ public class EventGenerator : MonoBehaviour
     /// </summary>
     /// <param name="eventPrefab"></param>
     /// <param name="eventTran"></param>
-    private void GenerateEvent(EnemyController eventPrefab, Transform eventTran) {
+    private void GenerateEnemy(EnemyController eventPrefab, Transform eventTran) {
         EnemyController enemy = Instantiate(eventPrefab, eventTran.position, eventPrefab.transform.rotation);
         enemy.SetUpEnemy(playerController, gameManager);
 

--- a/Assets/Scripts/GameTimeManager.cs
+++ b/Assets/Scripts/GameTimeManager.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameTimeManager : MonoBehaviour
+{
+    public int gameTime;
+
+    [SerializeField]
+    private GameManager gameManager;
+
+
+    private void Start() {
+        StartCoroutine(ObserveGameTime());
+    }
+
+    /// <summary>
+    /// ゲーム進行に合わせたゲーム時間の監視
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator ObserveGameTime() {
+        float timer = 0;
+        while (true) {
+            // GameUp になったら監視終了
+            if (gameManager.currentGameState == GameState.GameUp) {
+                break;
+            }
+
+            // ミッションが開始されたらカウントダウン開始
+            if (gameManager.currentGameState == GameState.Play_Mission) {
+                CountDown();
+            }
+            yield return null;
+        }
+
+        /// <summary>
+        /// ゲーム時間のカウントダウン
+        /// </summary>
+        void CountDown() {
+            // 時間の計測開始
+            timer += Time.deltaTime;
+
+            // 1秒ずつカウントダウン
+            if (timer > 1.0f) {
+                timer = 0;
+                gameTime--;
+
+                // 残り時間が 0 以下になったら
+                if (gameTime <= 0) {
+                    // ゲーム終了
+                    gameManager.currentGameState = GameState.GameUp;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// ゲーム時間の計算
+    /// </summary>
+    /// <param name="amount"></param>
+    public void CalcGameTime(int amount) {
+        gameTime += amount;
+    }
+}

--- a/Assets/Scripts/GameTimeManager.cs.meta
+++ b/Assets/Scripts/GameTimeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ad283b0d643e824993f0cf9cb39c235
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HideAction.cs
+++ b/Assets/Scripts/HideAction.cs
@@ -26,7 +26,9 @@ public class HideAction : MonoBehaviour
     private Vector3 originCameraPos;
     private Tween tween;
 
-    private bool isHide;
+    private bool isHide;  // true で隠れている状態
+    public bool IsHide { get => isHide; }
+
 
     /// <summary>
     /// デバッグ用
@@ -35,7 +37,6 @@ public class HideAction : MonoBehaviour
         SetOriginCameraTran(cameraTran.position);
     }
 
-    // Update is called once per frame
     void Update()
     {
         // ミッション以外は操作できない
@@ -64,8 +65,7 @@ public class HideAction : MonoBehaviour
             tween = chooseHideType == HideActionType.Left ? cameraTran.DOMove(leftHide, actionTime) : cameraTran.DOMove(rightHide, actionTime);
         } else {
             tween = cameraTran.DOMove(originCameraPos, actionTime);
-        }
-         
+        }     
         isHide = !isHide;
     }
 
@@ -82,5 +82,4 @@ public class HideAction : MonoBehaviour
     private void ResetOriginCameraTran() {
         originCameraPos = Vector3.zero;
     }
-
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -86,6 +86,10 @@ public class PlayerController : MonoBehaviour
     [SerializeField]
     private GameObject playerObj;
 
+    [SerializeField]
+    private HideAction hideAction;
+    public HideAction HideAction { get => hideAction; }
+
 
     void Start() {
         // Debug —p

--- a/Assets/Scripts/TimeEffect.cs
+++ b/Assets/Scripts/TimeEffect.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TimeEffect : MonoBehaviour
+{
+    public int timeValue;
+}

--- a/Assets/Scripts/TimeEffect.cs.meta
+++ b/Assets/Scripts/TimeEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2093c8da7919fd143864a10897f89698
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・EnemyController_Elete.cs 作成。プレイヤーが隠れていない限りは、攻撃判定確定のエネミー。タイムクライシスの赤い敵。
　上記の追加に伴い、EnemyBase.cs、EventGenerator.cs、HideAction.cs、PlayerController.cs を修正。

・TimeEffect.cs、GameTimeManager.cs 作成。イベント破棄時に、TimeEffect がアタッチされている場合にはゲーム時間の計算を行う機能を追加。
　エネミーの場合には加算(タイムクライシスの黄色い敵)、破壊してはならないイベントの場合には減算(ペナルティ)として活用。
　上記の追加に伴い、EnemyBase.cs 修正。

・デバッグ完了。